### PR TITLE
MUN-32 fix: @EnableJpaAuditing 추가

### DIFF
--- a/src/main/java/ureca/muneobe/MuneoBeApplication.java
+++ b/src/main/java/ureca/muneobe/MuneoBeApplication.java
@@ -2,7 +2,9 @@ package ureca.muneobe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MuneoBeApplication {
 


### PR DESCRIPTION
## 📝 요약(Summary)
JPA Auditing 기능을 활성화하기 위해 `@EnableJpaAuditing` 어노테이션을 메인 애플리케이션 클래스에 추가했습니다.

**변경 내용:**
- `MuneobeApplication.java`에 `@EnableJpaAuditing` 어노테이션 추가
- JPA Auditing 기능 활성화로 BaseEntity의 `@CreatedDate`, `@LastModifiedDate` 자동 설정 가능

**변경 이유:**
BaseEntity에서 `@CreatedDate`와 `@LastModifiedDate` 어노테이션을 사용하여 엔티티의 생성/수정 시간을 자동으로 관리하려고 했으나, JPA Auditing이 활성화되지 않아 해당 필드들이 자동으로 설정되지 않는 문제가 있었습니다.

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
N/A - 설정 관련 변경사항으로 UI 변경 없음

## 💬 공유사항 to 리뷰어
- JPA Auditing 활성화로 모든 엔티티의 생성/수정 시간이 자동으로 관리됩니다
- BaseEntity를 상속받는 모든 엔티티에서 `createdAt`, `updatedAt` 필드가 정상적으로 동작하는지 확인해 주세요

**고려사항:**
- 현재는 기본 설정으로 활성화했으나, 필요시 `auditorAwareRef`나 `dateTimeProviderRef` 추가 설정 가능
- 테스트 환경에서도 Auditing이 동작하는지 확인 필요

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 5분

---