### PR TITLE
Mun 39 로그인 cors해결

### DIFF
--- a/src/main/java/ureca/muneobe/common/auth/config/WebConfig.java
+++ b/src/main/java/ureca/muneobe/common/auth/config/WebConfig.java
@@ -2,6 +2,7 @@ package ureca.muneobe.common.auth.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import ureca.muneobe.common.auth.interceptor.LoginInterceptor;
@@ -17,5 +18,15 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addInterceptor(loginInterceptor)
                 .addPathPatterns("/**")  // 모든 경로에 적용
                 .excludePathPatterns("/css/**", "/js/**", "/images/**"); // 정적 리소스 제외
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                // TODO: 개발 및 운영 서버의 url 결정이 난다면, 추가 예정 + yml 설정으로 옮기기
+                .allowedOrigins("http://localhost:5173", "http://localhost:8080")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/ureca/muneobe/common/auth/interceptor/LoginInterceptor.java
+++ b/src/main/java/ureca/muneobe/common/auth/interceptor/LoginInterceptor.java
@@ -31,14 +31,8 @@ public class LoginInterceptor implements HandlerInterceptor {
 
         if (requireLogin(requestURI)) {
             if (!SessionUtil.isLoggedIn(session)) {
-                // AJAX 요청인 경우
-                if (isAjaxRequest(request)) {
-                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                    response.getWriter().write("{\"error\":\"로그인이 필요합니다\"}");
-                    return false;
-                }
-                // 일반 요청인 경우
-                response.sendRedirect("/login?redirectUrl=" + requestURI);
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("{\"error\":\"로그인이 필요합니다\"}");
                 return false;
             }
 

--- a/src/main/java/ureca/muneobe/common/auth/service/MemberService.java
+++ b/src/main/java/ureca/muneobe/common/auth/service/MemberService.java
@@ -23,9 +23,6 @@ public class MemberService {
 
         if (memberOpt.isPresent()) {
             Member member = memberOpt.get();
-            System.out.println("입력된 비밀번호: " + password);
-            System.out.println("저장된 해시: " + member.getPassword());
-            System.out.println("매칭 결과: " + passwordEncoder.matches(password, member.getPassword()));
             if (passwordEncoder.matches(password, member.getPassword())) {
                 return member;
             }

--- a/src/main/java/ureca/muneobe/common/auth/service/MemberService.java
+++ b/src/main/java/ureca/muneobe/common/auth/service/MemberService.java
@@ -15,14 +15,17 @@ public class MemberService {
 
     //TODO: 사용자 회원가입할때 직접 기입받을 정보들 수정 예정
 
-    private MemberRepository memberRepository;
-    private PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public Member authenticate(String username, String password) {
-        Optional<Member> memberOpt = memberRepository.findByName(username);
+    public Member authenticate(String email, String password) {
+        Optional<Member> memberOpt = memberRepository.findByEmail(email);
 
         if (memberOpt.isPresent()) {
             Member member = memberOpt.get();
+            System.out.println("입력된 비밀번호: " + password);
+            System.out.println("저장된 해시: " + member.getPassword());
+            System.out.println("매칭 결과: " + passwordEncoder.matches(password, member.getPassword()));
             if (passwordEncoder.matches(password, member.getPassword())) {
                 return member;
             }


### PR DESCRIPTION
## 📝 요약(Summary)
로그인 인증 방식을 사용자명(name) 기반에서 이메일(email) 기반으로 변경하고, CORS 설정을 추가하여 프론트엔드와의 API 통신을 지원하도록 개선했습니다.

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 버그 수정
- [x] 코드 리팩토링
- [x] 새로운 기능 추가

## 📋 주요 변경사항

### 1. CORS 설정 추가
- **WebConfig**에 `addCorsMappings()` 메소드 추가
- 허용 오리진: `http://localhost:5173`, `http://localhost:8080`
- 모든 HTTP 메소드 및 헤더 허용
- `allowCredentials(true)` 설정으로 세션 쿠키 전송 지원

### 2. 인터셉터 단순화
- **LoginInterceptor**에서 AJAX/일반 요청 구분 로직 제거
- 모든 미인증 요청에 대해 일관된 JSON 응답 (401 Unauthorized) 반환
- 프론트엔드 API 통신 방식에 맞게 개선

## 💬 공유사항 to 리뷰어
- CORS 설정의 허용 오리진이 개발 환경용이므로, 운영 환경 배포 시 yml 설정으로 분리하는 것이 좋겠습니다.
- 로그인 실패 시 응답 형태가 변경되었으므로 프론트엔드 에러 핸들링 코드도 함께 확인해주세요.

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분