### PR TITLE
MUN-44 refactor: 배포 서버 url 에 맞춰 cors 설정

### DIFF
--- a/src/main/java/ureca/muneobe/common/auth/config/CorsProperties.java
+++ b/src/main/java/ureca/muneobe/common/auth/config/CorsProperties.java
@@ -1,0 +1,18 @@
+package ureca.muneobe.common.auth.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@ConfigurationProperties(prefix = "app.cors")
+@Data
+public class CorsProperties {
+    private List<String> allowedOrigins;
+    private String allowedMethods = "*";
+    private String allowedHeaders = "*";
+    private boolean allowCredentials = true;
+    private String pathPattern = "/**";
+}

--- a/src/main/java/ureca/muneobe/common/auth/config/WebConfig.java
+++ b/src/main/java/ureca/muneobe/common/auth/config/WebConfig.java
@@ -1,6 +1,6 @@
 package ureca.muneobe.common.auth.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -8,25 +8,25 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import ureca.muneobe.common.auth.interceptor.LoginInterceptor;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    @Autowired
-    private LoginInterceptor loginInterceptor;
+    private final LoginInterceptor loginInterceptor;
+    private final CorsProperties corsProperties;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginInterceptor)
-                .addPathPatterns("/**")  // 모든 경로에 적용
-                .excludePathPatterns("/css/**", "/js/**", "/images/**"); // 정적 리소스 제외
+                .addPathPatterns("/**")
+                .excludePathPatterns("/css/**", "/js/**", "/images/**");
     }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/**")
-                // TODO: 개발 및 운영 서버의 url 결정이 난다면, 추가 예정 + yml 설정으로 옮기기
-                .allowedOrigins("http://localhost:5173", "http://localhost:8080")
-                .allowedMethods("*")
-                .allowedHeaders("*")
-                .allowCredentials(true);
+        registry.addMapping(corsProperties.getPathPattern())
+                .allowedOrigins(corsProperties.getAllowedOrigins().toArray(new String[0]))
+                .allowedMethods(corsProperties.getAllowedMethods().split(","))
+                .allowedHeaders(corsProperties.getAllowedHeaders().split(","))
+                .allowCredentials(corsProperties.isAllowCredentials());
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,6 +20,13 @@ server:
       cookie:
         secure: false  # 개발서버에서는 HTTP 허용
 
+app:
+  cors:
+    allowed-origins:
+      - "http://localhost:5173"
+      - "http://localhost:8080"
+      - "https://web-muneo-fe-m3d8djgv98deef95.sel4.cloudtype.app"
+
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -261,3 +261,11 @@ server:
       cookie:
         http-only: true
         same-site: strict
+app:
+  cors:
+    allowed-origins:
+      - "http://localhost:3000"
+    allowed-methods: "*"
+    allowed-headers: "*"
+    allow-credentials: true
+    path-pattern: "/**"


### PR DESCRIPTION
## 📝 요약(Summary)

CORS 설정을 하드코딩에서 YAML 설정 파일로 분리하여 환경별 관리를 가능하게 하는 리팩토링을 수행했습니다. 기존에는 WebConfig에서 직접 도메인을 지정했지만, 이제 CorsProperties 클래스를 통해 application.yml과 application-dev.yml에서 환경별로 다른 CORS 설정을 관리할 수 있습니다.

## 🛠️ PR 유형
어떤 변경 사항이 있나요?
- [x] 코드 리팩토링
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
N/A (백엔드 설정 변경)

## 💬 공유사항 to 리뷰어

### 주요 변경사항
1. **CorsProperties 클래스 추가**: `@ConfigurationProperties`를 사용하여 YAML에서 CORS 설정을 주입받는 설정 클래스를 생성
2. **WebConfig 리팩토링**: 
   - `@Autowired` → `@RequiredArgsConstructor`로 의존성 주입 방식 변경
   - 하드코딩된 CORS 설정을 CorsProperties를 통해 동적으로 설정하도록 변경
3. **환경별 YAML 설정**:
   - `application.yml`: 기본 설정 (로컬 개발용 3000 포트)
   - `application-dev.yml`: 개발/운영 환경용 도메인들 추가

### 중점 리뷰 사항
- CorsProperties의 기본값 설정이 적절한지 확인 부탁드립니다
- 환경별 YAML 설정이 실제 사용 환경과 일치하는지 검토 부탁드립니다
- `split(",")`을 사용한 부분이 `"*"` 값에서도 정상 동작하는지 확인했지만, 더 나은 방법이 있다면 제안 부탁드립니다

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분