### PR TITLE
MUN-51 feat: 스트리밍 데이터 응답값 저장(재시도 로직 포함) 및 데이터 순서 보장

### DIFF
--- a/src/main/java/ureca/muneobe/common/chat/service/ChatService.java
+++ b/src/main/java/ureca/muneobe/common/chat/service/ChatService.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
 import ureca.muneobe.common.auth.respository.MemberRepository;
 import ureca.muneobe.common.auth.entity.Member;
 import ureca.muneobe.common.chat.entity.Chat;
+import ureca.muneobe.common.chat.entity.ChatType;
 import ureca.muneobe.common.chat.repository.ChatRedisRepository;
 import ureca.muneobe.common.chat.repository.ChatRepository;
 import ureca.muneobe.common.chat.dto.result.ChatResult;
@@ -18,12 +20,14 @@ import ureca.muneobe.common.chat.service.strategy.RoutingStrategy;
 import ureca.muneobe.common.chat.service.strategy.RoutingStrategyFactory;
 import ureca.muneobe.common.openai.OpenAiClient;
 
+import java.time.Duration;
 import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChatService {
+
     private final OpenAiClient openAiClient;
     private final ChatRedisRepository chatRedisRepository;
     private final RoutingStrategyFactory routingStrategyFactory;
@@ -34,12 +38,37 @@ public class ChatService {
     /**
      * 채팅 응답 생성
      */
-    public Flux<String> createChatResponse(ChatResult chatResult) {
-        return Mono.fromCallable(()->chatMessagePreProcessor.preProcess(chatResult))
+    public Flux<String> createChatResponse(final ChatResult chatResult) {
+        return Mono.fromCallable(() -> chatMessagePreProcessor.preProcess(chatResult))
                 .subscribeOn(Schedulers.boundedElastic())
                 .flatMap(preProcessResult -> openAiClient.callFirstPrompt(preProcessResult))
-                .flatMapMany(firstPromptResult -> searchAndCallSecondPrompt(firstPromptResult))
-                .onErrorResume(Mono::error);
+                .flatMapMany(firstPromptResult -> saveResponse(chatResult, firstPromptResult))
+                .onErrorResume(error -> {
+                    log.error("에러 발생 : {}", error.getMessage(), error);
+                    return Flux.empty();
+                });
+    }
+
+    private Flux<String> saveResponse(final ChatResult chatResult, final FirstPromptResult firstPromptResult) {
+
+        final StringBuilder buffer = new StringBuilder();
+
+        return searchAndCallSecondPrompt(firstPromptResult)
+                .concatMap(line -> Mono.fromSupplier(() -> {
+                    buffer.append(line);
+                    return line;
+                }))
+                .doOnComplete(() -> {
+                    final String memberName = chatResult.getMemberName();
+                    final String text = buffer.toString();
+                    Mono.fromRunnable(() ->
+                                    chatRedisRepository.saveChat(memberName, text, ChatType.RESPONSE)
+                            )
+                            .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)))
+                            .doOnError(e -> log.error("Redis 저장 실패: {}", e.getMessage(), e))
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .subscribe();
+                });
     }
 
     /**


### PR DESCRIPTION
## 📝 요약(Summary)

스트리밍 데이터 응답값 저장(재시도 로직 포함) + 스트리밍 데이터 순서 보장을 구현했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

가용성을 높이기 위한 재시도 로직을 추가했는데, 해당 코드의 전략이 좋은 방향인지 리뷰해주시면 감사하겠습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 🤔 Review 예상 시간
- 10분
