### PR TITLE
Mun 56 mypage crud

### DIFF
--- a/src/main/java/ureca/muneobe/common/auth/controller/AuthController.java
+++ b/src/main/java/ureca/muneobe/common/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package ureca.muneobe.common.auth.controller;
 
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,7 @@ import ureca.muneobe.common.auth.utils.SessionUtil;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
@@ -26,7 +28,7 @@ public class AuthController {
     public ResponseEntity<Map<String, Object>> login(@RequestBody LoginRequest loginRequest,
                                                      HttpSession session) {
         Map<String, Object> response = new HashMap<>();
-
+        log.info(session.getId());
         try {
             Member member = memberService.authenticate(loginRequest.getEmail(), loginRequest.getPassword());
 

--- a/src/main/java/ureca/muneobe/common/auth/entity/Member.java
+++ b/src/main/java/ureca/muneobe/common/auth/entity/Member.java
@@ -8,7 +8,11 @@ import lombok.NoArgsConstructor;
 import ureca.muneobe.common.auth.entity.enums.Category;
 import ureca.muneobe.common.auth.entity.enums.Gender;
 import ureca.muneobe.common.auth.entity.enums.Role;
+import ureca.muneobe.common.subscription.entity.Subscription;
 import ureca.muneobe.global.common.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -52,6 +56,9 @@ public class Member extends BaseEntity {
 
     @Column(name = "use_amount")
     private Integer useAmount;
+
+    @OneToMany(mappedBy = "member")
+    private List<Subscription> subscriptions = new ArrayList<>();
 
     @Builder
     private Member(String name, String password, String phoneNumber,

--- a/src/main/java/ureca/muneobe/common/mypage/controller/MyPageController.java
+++ b/src/main/java/ureca/muneobe/common/mypage/controller/MyPageController.java
@@ -15,7 +15,7 @@ import ureca.muneobe.global.response.ResponseBody;
 public class MyPageController {
     private final MyPageService myPageService;
 
-    @GetMapping("/mypage")
+    @GetMapping("/v1/mypage")
     public ResponseEntity<ResponseBody<MyPageResponse>> readMyPage(
             HttpSession httpSession
     ){

--- a/src/main/java/ureca/muneobe/common/mypage/controller/MyPageController.java
+++ b/src/main/java/ureca/muneobe/common/mypage/controller/MyPageController.java
@@ -1,23 +1,25 @@
-//package ureca.muneobe.common.mypage.controller;
-//
-//import jakarta.servlet.http.HttpSession;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.GetMapping;
-//import org.springframework.web.bind.annotation.RestController;
-//import ureca.muneobe.common.auth.utils.SessionUtil;
-//import ureca.muneobe.global.response.ResponseBody;
-//
-//@RestController
-//@RequiredArgsConstructor
-//public class MyPageController {
-//    private final MyPageService myPageService;
-//
-//    @GetMapping("/mypage")
-//    public ResponseEntity<ResponseBody<MyPageResponse>> readMyPage(
-//            HttpSession httpSession
-//    ){
-//        return ResponseEntity.ok().body(
-//                ResponseBody.success(myPageService.findMyInfo(SessionUtil.getLoginMember(httpSession))));
-//    }
-//}
+package ureca.muneobe.common.mypage.controller;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ureca.muneobe.common.auth.utils.SessionUtil;
+import ureca.muneobe.common.mypage.dto.response.MyPageResponse;
+import ureca.muneobe.common.mypage.service.MyPageService;
+import ureca.muneobe.global.response.ResponseBody;
+
+@RestController
+@RequiredArgsConstructor
+public class MyPageController {
+    private final MyPageService myPageService;
+
+    @GetMapping("/mypage")
+    public ResponseEntity<ResponseBody<MyPageResponse>> readMyPage(
+            HttpSession httpSession
+    ){
+        return ResponseEntity.ok().body(
+                ResponseBody.success(myPageService.findMyInfo(SessionUtil.getLoginMember(httpSession))));
+    }
+}

--- a/src/main/java/ureca/muneobe/common/mypage/dto/response/MplanResponse.java
+++ b/src/main/java/ureca/muneobe/common/mypage/dto/response/MplanResponse.java
@@ -1,0 +1,22 @@
+package ureca.muneobe.common.mypage.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import ureca.muneobe.common.mplan.entity.Mplan;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MplanResponse {
+    private Long id;
+    private String name;
+
+    public static MplanResponse from(Mplan mplan){
+        return MplanResponse.builder()
+                .id(mplan.getId())
+                .name(mplan.getName())
+                .build();
+
+    }
+}

--- a/src/main/java/ureca/muneobe/common/mypage/dto/response/MyPageResponse.java
+++ b/src/main/java/ureca/muneobe/common/mypage/dto/response/MyPageResponse.java
@@ -17,7 +17,6 @@ import java.time.LocalDateTime;
 public class MyPageResponse {
     private Long id;
     private String email;
-    private String password;
     private String phoneNumber;
     private Integer old;
     private Gender gender;
@@ -34,7 +33,6 @@ public class MyPageResponse {
         return MyPageResponse.builder()
                 .id(member.getId())
                 .email(member.getEmail())
-                .password(member.getPassword())
                 .phoneNumber(member.getPhoneNumber())
                 .old(member.getOld())
                 .gender(member.getGender())

--- a/src/main/java/ureca/muneobe/common/mypage/dto/response/MyPageResponse.java
+++ b/src/main/java/ureca/muneobe/common/mypage/dto/response/MyPageResponse.java
@@ -1,19 +1,51 @@
-//package ureca.muneobe.common.mypage.dto.response;
-//
-//import java.time.LocalDateTime;
-//import lombok.AllArgsConstructor;
-//import lombok.Builder;
-//import lombok.Getter;
-//import lombok.NoArgsConstructor;
-//
-//@Getter
-//@Builder
-//@NoArgsConstructor
-//@AllArgsConstructor
-//public class MyPageResponse {
-//    private String name;
-//    private
-//    private String phoneNumber;
-//    private LocalDateTime createdAt;
-//    private
-//}
+package ureca.muneobe.common.mypage.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ureca.muneobe.common.auth.entity.Member;
+import ureca.muneobe.common.auth.entity.enums.Category;
+import ureca.muneobe.common.auth.entity.enums.Gender;
+import ureca.muneobe.common.auth.entity.enums.Role;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyPageResponse {
+    private Long id;
+    private String email;
+    private String password;
+    private String phoneNumber;
+    private Integer old;
+    private Gender gender;
+    private String name;
+    private Category category;
+    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
+    private Boolean activeYn;
+    private Role role;
+    private Integer useAmount;
+    private SubscriptionsResponse subscriptionsResponse;
+
+    public static MyPageResponse from(Member member) {
+        return MyPageResponse.builder()
+                .id(member.getId())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .phoneNumber(member.getPhoneNumber())
+                .old(member.getOld())
+                .gender(member.getGender())
+                .name(member.getName())
+                .category(member.getCategory())
+                .createdAt(member.getCreatedAt())
+                .deletedAt(member.getDeletedAt())
+                .activeYn(member.getActiveYn())
+                .role(member.getRole())
+                .useAmount(member.getUseAmount())
+                .subscriptionsResponse(SubscriptionsResponse.from(member.getSubscriptions()))
+                .build();
+    }
+}

--- a/src/main/java/ureca/muneobe/common/mypage/dto/response/SubscriptionResponse.java
+++ b/src/main/java/ureca/muneobe/common/mypage/dto/response/SubscriptionResponse.java
@@ -1,0 +1,31 @@
+package ureca.muneobe.common.mypage.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import ureca.muneobe.common.subscription.entity.Subscription;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SubscriptionResponse {
+    private Long id;
+    private Integer fee;
+    private LocalDateTime createdAt;
+    private LocalDateTime deletedAt;
+    private LocalDateTime updatedAt;
+    private MplanResponse mplanResponse;
+
+    public static SubscriptionResponse from(Subscription subscription){
+        return SubscriptionResponse.builder()
+                .id(subscription.getId())
+                .fee(subscription.getFee())
+                .createdAt(subscription.getCreatedAt())
+                .deletedAt(subscription.getDeletedAt())
+                .updatedAt(subscription.getUpdatedAt())
+                .mplanResponse(MplanResponse.from(subscription.getMplan()))
+                .build();
+    }
+}

--- a/src/main/java/ureca/muneobe/common/mypage/dto/response/SubscriptionsResponse.java
+++ b/src/main/java/ureca/muneobe/common/mypage/dto/response/SubscriptionsResponse.java
@@ -1,0 +1,21 @@
+package ureca.muneobe.common.mypage.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import ureca.muneobe.common.subscription.entity.Subscription;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SubscriptionsResponse {
+    private List<SubscriptionResponse> subscriptionsResponse;
+
+    public static SubscriptionsResponse from(List<Subscription> subscriptions){
+        return SubscriptionsResponse.builder()
+                .subscriptionsResponse(subscriptions.stream().map(SubscriptionResponse::from).toList())
+                .build();
+    }
+}

--- a/src/main/java/ureca/muneobe/common/mypage/service/MyPageService.java
+++ b/src/main/java/ureca/muneobe/common/mypage/service/MyPageService.java
@@ -1,19 +1,24 @@
-//package ureca.muneobe.common.mypage.service;
-//
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.stereotype.Service;
-//import ureca.muneobe.common.auth.entity.Member;
-//import ureca.muneobe.common.auth.respository.MemberRepository;
-//import ureca.muneobe.common.mypage.dto.response.MyPageResponse;
-//
-//@Service
-//@RequiredArgsConstructor
-//public class MyPageService {
-//    private final MemberRepository memberRepository;
-//    private final SubscriptionRepository subscriptionRepository;
-//
-//
-//    public MyPageResponse findMyInfo(Member loginMember) {
-//        return null;
-//    }
-//}
+package ureca.muneobe.common.mypage.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import ureca.muneobe.common.auth.entity.Member;
+import ureca.muneobe.common.auth.respository.MemberRepository;
+import ureca.muneobe.common.mypage.dto.response.MyPageResponse;
+import ureca.muneobe.global.exception.GlobalException;
+import ureca.muneobe.global.response.ErrorCode;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+    private final MemberRepository memberRepository;
+
+    public MyPageResponse findMyInfo(Member loginMember) {
+        return getMyPageResponse(loginMember.getId());
+    }
+
+    private MyPageResponse getMyPageResponse(Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(() -> new GlobalException(ErrorCode.UNAUTHORIZED));
+        return MyPageResponse.from(member);
+    }
+}


### PR DESCRIPTION
## 📝 요약(Summary)

- **마이페이지 기능** 구현: 로그인된 사용자의 정보를 조회하는 API 추가
- `Member` 엔티티에 `subscriptions` 연관관계 추가
- 마이페이지 응답을 위한 DTO 계층 (`MyPageResponse`, `SubscriptionsResponse`, `SubscriptionResponse`, `MplanResponse`) 생성
- 기존 주석 처리되어 있던 `MyPageController`, `MyPageService` 복원 및 구현
- 로그인을 위한 `sessionId` 로그 추가

---

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📸 스크린샷 (선택)
X

---

## 💬 공유사항 to 리뷰어

- 로그인 세션을 통해 사용자 식별을 하므로, 테스트 시 **로그인 → `/v1/mypage` 호출** 순서로 진행해주세요.
- 응답 객체 구조는 프론트 명세서 기반으로 설계되어 있습니다. `subscriptionsResponse` 필드 하위에 구독 및 플랜 정보가 포함됩니다.
- 혹시 누락된 데이터가 있다면 해당 DTO 구조에서 조정 가능합니다.

---

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

---

## 🤔 Review 예상 시간

- 5분