### PR TITLE
MUN-59 refactor: 요금제 추가 기능 수정

### DIFF
--- a/src/main/java/ureca/muneobe/common/addongroup/dto/response/AddonGroupAddonResponse.java
+++ b/src/main/java/ureca/muneobe/common/addongroup/dto/response/AddonGroupAddonResponse.java
@@ -15,17 +15,11 @@ import ureca.muneobe.common.addon.entity.AddonType;
 public class AddonGroupAddonResponse {
     private Long id;
     private String name;
-    private String description;
-    private Integer price;
-    private AddonType addonType;
 
     public static AddonGroupAddonResponse from(Addon addon){
         return AddonGroupAddonResponse.builder()
                 .id(addon.getId())
                 .name(addon.getName())
-                .description(addon.getDescription())
-                .price(addon.getPrice())
-                .addonType(addon.getAddonType())
                 .build();
     }
 }

--- a/src/main/java/ureca/muneobe/common/mplan/dto/request/AddonGroupRequest.java
+++ b/src/main/java/ureca/muneobe/common/mplan/dto/request/AddonGroupRequest.java
@@ -1,0 +1,10 @@
+package ureca.muneobe.common.mplan.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddonGroupRequest {
+    private Long id;
+}

--- a/src/main/java/ureca/muneobe/common/mplan/dto/request/MplanCreateRequest.java
+++ b/src/main/java/ureca/muneobe/common/mplan/dto/request/MplanCreateRequest.java
@@ -1,12 +1,34 @@
 package ureca.muneobe.common.mplan.dto.request;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import ureca.muneobe.common.addon.entity.AddonType;
+import ureca.muneobe.common.addongroup.dto.response.AddonGroupAddonResponse;
+import ureca.muneobe.common.mplan.entity.DataType;
+import ureca.muneobe.common.mplan.entity.MplanType;
+import ureca.muneobe.common.mplan.entity.Qualification;
 
 @Getter
 @NoArgsConstructor
 public class MplanCreateRequest {
+    //mplan
     private String name;
-    private Long mplanDetailId;
-    private Long addonGroupId;
+
+    //mplan_detail
+    private Integer basicDataAmount;
+    private Integer dailyData;
+    private Integer sharingData;
+    private Integer monthlyPrice;
+    private Integer voiceCallVolume;
+    private Boolean textMessage;
+    private Integer subDataSpeed;
+    private Qualification qualification;
+    private MplanType mplanType;
+    private DataType dataType;
+
+    //addon_group
+    private AddonGroupRequest addonGroupRequest;
 }

--- a/src/main/java/ureca/muneobe/common/mplan/entity/MplanDetail.java
+++ b/src/main/java/ureca/muneobe/common/mplan/entity/MplanDetail.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import ureca.muneobe.common.mplan.dto.request.MplanCreateRequest;
 import ureca.muneobe.common.mplan.dto.request.MplanDetailCreateRequest;
 import ureca.muneobe.global.common.BaseEntity;
 
@@ -68,6 +69,21 @@ public class MplanDetail extends BaseEntity {
     private List<Mplan> mplan = new ArrayList<>();
 
     public static MplanDetail from(MplanDetailCreateRequest mplanDetailCreateRequest){
+        return MplanDetail.builder()
+                .basicDataAmount(mplanDetailCreateRequest.getBasicDataAmount())
+                .dailyData(mplanDetailCreateRequest.getDailyData())
+                .sharingData(mplanDetailCreateRequest.getSharingData())
+                .monthlyPrice(mplanDetailCreateRequest.getMonthlyPrice())
+                .voiceCallVolume(mplanDetailCreateRequest.getVoiceCallVolume())
+                .textMessage(mplanDetailCreateRequest.getTextMessage())
+                .subDataSpeed(mplanDetailCreateRequest.getSubDataSpeed())
+                .qualification(mplanDetailCreateRequest.getQualification())
+                .mplanType(mplanDetailCreateRequest.getMplanType())
+                .dataType(mplanDetailCreateRequest.getDataType())
+                .build();
+    }
+
+    public static MplanDetail from(MplanCreateRequest mplanDetailCreateRequest){
         return MplanDetail.builder()
                 .basicDataAmount(mplanDetailCreateRequest.getBasicDataAmount())
                 .dailyData(mplanDetailCreateRequest.getDailyData())

--- a/src/main/java/ureca/muneobe/common/mplan/service/MplanService.java
+++ b/src/main/java/ureca/muneobe/common/mplan/service/MplanService.java
@@ -42,9 +42,9 @@ public class MplanService {
     }
 
     private Mplan getMplan(MplanCreateRequest mplanCreateRequest) {
-        MplanDetail mplanDetailProxy = mplanDetailRepository.getReferenceById(mplanCreateRequest.getMplanDetailId());
-        AddonGroup addonGroupProxy = addonGroupRepository.getReferenceById(mplanCreateRequest.getAddonGroupId());
-        return Mplan.of(mplanCreateRequest, addonGroupProxy, mplanDetailProxy);
+        MplanDetail mplanDetail = mplanDetailRepository.save(MplanDetail.from(mplanCreateRequest));
+        AddonGroup addonGroup = addonGroupRepository.getReferenceById(mplanCreateRequest.getAddonGroupRequest().getId());
+        return Mplan.of(mplanCreateRequest, addonGroup, mplanDetail);
     }
 
     private MplanCreateResponse getMplanCreateResponse(Mplan mplan) {


### PR DESCRIPTION
**📝 요약(Summary)**
요금제 생성 요청 시 필요한 상세정보(`MplanDetail`)를 직접 등록할 수 있도록 변경하였습니다. 또한 `AddonGroup` 요청 구조를 객체로 감싸고, 기존에 불필요하게 포함되던 `AddonGroupAddonResponse` 필드를 제거했습니다.

---

**🛠️ PR 유형**  
어떤 변경 사항이 있나요?

* [x] 새로운 기능 추가  
* [ ] 버그 수정  
* [ ] CSS 등 사용자 UI 디자인 변경  
* [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)  
* [x] 코드 리팩토링  
* [ ] 주석 추가 및 수정  
* [ ] 문서 수정  
* [ ] 테스트 추가, 테스트 리팩토링  
* [ ] 빌드 부분 혹은 패키지 매니저 수정  
* [ ] 파일 혹은 폴더명 수정  
* [ ] 파일 혹은 폴더 삭제  

---

**🔧 주요 변경사항**
- `AddonGroupAddonResponse`: 불필요한 필드 (`description`, `price`, `addonType`) 제거
- `AddonGroupRequest`: AddonGroup ID를 객체로 감싸도록 request 구조 생성
- `MplanCreateRequest`:
  - `mplanDetailId` → 상세 필드 직접 입력으로 변경
  - `addonGroupId` → `AddonGroupRequest`로 교체
- `MplanDetail.from(MplanCreateRequest)` 정적 팩토리 메서드 추가
- `MplanService#getMplan()` 로직 수정: `MplanDetail`을 새로 생성하도록 변경

---

**📸스크린샷 (선택)**  
_해당 없음_

---

**💬 공유사항 to 리뷰어**
- 이제 `MplanCreateRequest`는 `MplanDetail` 정보 전체를 포함해야 하며, 더 이상 `mplanDetailId`를 전달하지 않습니다.
- `AddonGroupRequest`로 ID를 감싼 이유는 추후 요청 확장을 고려한 구조입니다.
- `AddonGroupAddonResponse`에서 제거된 필드가 필요하다면, 명확한 기준에 따라 다시 포함시켜야 합니다.

---

**⚠️ 주의사항**
- 기존에 `getReferenceById()`로 조회하던 `MplanDetail`은 더 이상 사용하지 않으며, `save()`로 항상 새로 생성합니다.
- 향후 `MplanDetail`이 공유되는 구조로 바뀐다면 이 로직을 다시 수정해야 합니다.

---

**✅ PR Checklist**
* [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  
* [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

---

**🤔 Review 예상 시간**
* 5~10분