### PR TITLE
MUN-65 hotfix: 세션끊길 때 저장 로직 수정

### DIFF
--- a/src/main/java/ureca/muneobe/common/chat/event/WebSocketEventListener.java
+++ b/src/main/java/ureca/muneobe/common/chat/event/WebSocketEventListener.java
@@ -18,7 +18,7 @@ public class WebSocketEventListener {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
 
         // 웹소켓 세션에 저장된 사용자 정보 가져오기
-        String username = (String) accessor.getSessionAttributes().get("username");
+        String username = (String) accessor.getSessionAttributes().get("memberName");
 
         if (username != null) {
             chatService.saveChatLogToDB(username);


### PR DESCRIPTION
hotfix: 세션끊길 때 getAttributes("username")으로 null 처리 해결